### PR TITLE
libcameraservice: Add support for rui camera mode

### DIFF
--- a/services/camera/libcameraservice/CameraService.cpp
+++ b/services/camera/libcameraservice/CameraService.cpp
@@ -3565,6 +3565,15 @@ status_t CameraService::BasicClient::startCameraOps() {
         ALOGI("Disabling miui camera mode");
     }
 
+    // Configure rui camera mode
+    if (strcmp(String8(mClientPackageName).string(), "com.oppo.camera") == 0) {
+        SetProperty("oppo.camera.packname", "com.oppo.camera");
+        ALOGI("Enabling rui camera mode");
+    } else {
+        SetProperty("oppo.camera.packname", "");
+        ALOGI("Disabling rui camera mode");
+    }
+
     // Transition device availability listeners from PRESENT -> NOT_AVAILABLE
     sCameraService->updateStatus(StatusInternal::NOT_AVAILABLE, mCameraIdStr);
 


### PR DESCRIPTION
** based on https://github.com/PixelExtended/frameworks_av/commit/f4219ab8f2d20cce005fc6984e08668a49184c00 ** legacy realme devices launched with Android P and Android Q are setting this prop from libopluscameraservice but we dont use that in custom roms ** This prop will unlock all the streams and features of RUI Stock Camera ** To emulate the same, we are setting this prop by comparing camera client name ** Setting this prop from system/vendor prop file will break Telegram, Whatsapp and other apps camera functionality ** Dynamically setting this prop based on package name will solve the above issue